### PR TITLE
Notation of dates 

### DIFF
--- a/jquery.icalendar.js
+++ b/jquery.icalendar.js
@@ -276,6 +276,10 @@ $.extend(iCalendar.prototype, {
 	   @param  local     (boolean) true if this should be a local date/time
 	   @return  (string) the formatted date/time */
 	formatDateTime: function(dateTime, local) {
+		if (dateTime.getSeconds() === 0 &&  dateTime.getMinutes() === 0 && dateTime.getHours() === 0) {
+			return this.formatDate(dateTime, local);
+		}
+		
 		return (!dateTime ? '' : (local ?
 			'' + dateTime.getFullYear() + this._ensureTwo(dateTime.getMonth() + 1) +
 			this._ensureTwo(dateTime.getDate()) + 'T' + this._ensureTwo(dateTime.getHours()) +


### PR DESCRIPTION
iCal for Mac detects
DTSTART:20130302
DTEND:20130302
as a whole day event but not 
DTSTART:20130302T000000Z
DTEND:20130302T000000Z
Therefor we can notate a date like new Date(2013,02,02,00,00,00) in the shorter notation
